### PR TITLE
Fix wokerman to v3.5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": "^7",
     "hamlet-framework/http": "@stable",
-    "workerman/workerman": "@stable"
+    "workerman/workerman": "^3.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The new workerman v4, it's incompatible with the 3.5.x.

So will be working till you make the changes.
And fix it for the benchmark too.